### PR TITLE
allow ondblclick for works.ejs

### DIFF
--- a/source/js/blog.js
+++ b/source/js/blog.js
@@ -11,7 +11,7 @@ $(function() {
 
 
 // make all images responsive
-/* 
+/*
  * Unuse by Hux
  * actually only Portfolio-Pages can't use it and only post-img need it.
  * so I modify the _layout/post and CSS to make post-img responsive!
@@ -27,7 +27,7 @@ $(document).ready(function() {
 });
 
 // responsive embed videos
-$(document).ready(function () { 
+$(document).ready(function () {
     $('iframe[src*="youtube.com"]').wrap('<div class="embed-responsive embed-responsive-16by9"></div>');
     $('iframe[src*="youtube.com"]').addClass('embed-responsive-item');
     $('iframe[src*="vimeo.com"]').wrap('<div class="embed-responsive embed-responsive-16by9"></div>');
@@ -75,9 +75,9 @@ function scrollCheck(scrollTarget, toggleClass, scrollHeight){
     博文页面
 */
 (function(){
-    var navbar = document.querySelector('.navbar-custom');
-    var introHeader = document.querySelector('.intro-header').offsetHeight;
     if (isPages('data-ispost')){
+        var navbar = document.querySelector('.navbar-custom');
+        var introHeader = document.querySelector('.intro-header').offsetHeight;
         var introHeader = introHeader > 497 ? introHeader : 400;
         var toc = document.querySelector('.toc-wrap');
         var postTitle = document.querySelector('.post-title-haojen');
@@ -95,6 +95,3 @@ function scrollCheck(scrollTarget, toggleClass, scrollHeight){
         }, 500)
     }
 })();
-
-
-


### PR DESCRIPTION
Hey @Haojen, here's a quick fix for something I came across - 

Problem:
Double clicking the nav bar on a `works.ejs` layout page doesn't scroll to the top.  You can see it happen on the [demo](http://haojen.github.io/my-works/).

Reason:
A property error posts when using the `works.ejs` layout (`blog.js:79 Uncaught TypeError: Cannot read property 'offsetHeight' of null`).  `works.ejs` does not use the css class `intro-header` which is used as a selector by `blog.js` on line 79.  This prevents the double click scroll event from attaching, because it is attached in the next code block.

Fix:
Wrapping the entire `post` navigation function body in the `isPages('data-ispost')` conditional prevents the querySelector() call until needed.
